### PR TITLE
fix: readthedocs python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 1
 formats: []
 
 python:
-  version: 3.6
+  version: 3.7
   install:
     - method: setuptools
       path: package


### PR DESCRIPTION
## Description
closes #37 
autodoc requires the dataclasses package which was introduced in python 3.7. so, .readthedocs.yaml is updated here so that the modules show up properly on the docs site.

relevant build log showing `WARNING: autodoc: failed to import module 'example' from module 'pyisic._standards'; the following exception was raised:
No module named 'dataclasses'`: https://readthedocs.org/projects/pyisic/builds/15023633/

## Types of changes
<!-- Put an `x` in the boxes that apply --->
What types of changes does your code introduce:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply --->
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... --->
